### PR TITLE
Testing with nose2, travis, and coverage/coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = False
+source = python
+
+[report]
+precision = 1
+ignore_errors = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install:
+  - "pip install -r requirements-dev.txt"
+  - "pip install coveralls"
+script:
+  - nose2
+after_success:
+  - coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,11 @@ Testing
 -------
 
 Test coverage is admittedly pretty bad right now, so help out by writing
- tests for new code. To run the tests, use:
+ tests for new code. To run the tests, make sure that you've installed
+  the dev requirements, and use the command found in the bin directory
+  of your virtualenv:
 
-    $ nosetests --with-coverage
-    $ coverage html
+    $ nose2
 
 We are working on getting travis or a similar CI service running.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ accessing web pages. They all implement the same general functionality:
  * get_page_source(url): takes in a url, and returns a Webpage object, 
  containing all we can find out about that webpage.  Notably it's source.
  
-The 4 implimented engines are:
+The 4 implemented engines are:
 
  * DefaultEngine: backed by python standard urllib
  * SeleniumEngine: backed by selenium and the firefox driver

--- a/nose2.cfg
+++ b/nose2.cfg
@@ -1,0 +1,9 @@
+[unittest]
+start-dir = tests
+code-directories = rasp
+
+[coverage]
+always-on = True
+coverage = rasp
+coverage-config = .coveragerc
+coverage-report = html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,11 @@
-selenium
-stem
+# inherit the project requirements
+-r requirements.txt
 
+# packages for the docs
 sphinx
 sphinx_rtd_theme
+
+# packages for testing and coverage
+nose2
+cov-core
+coverage


### PR DESCRIPTION
This PR fixed #4, and adds in some basic infrastructure.  

 * The test suite is run by nose2, which is a more liberally licensed and actually maintained version of nose. It uses the nose2.cfg file to configure where to look for tests and what plugins to use.
 * Coverage is run according to the .coveragerc file, and populates a directory of HTML in htmlcov (which is gitignored currently). 
 * Travis should run all of this on every commit according to the .travis.yml file, and will post the outcome to coveralls, which will track our test coverage. 

Once those two services are set up we can add badges to the readme to show current build and coverage statuses. 