### PR TITLE
Prototype Asyncio-based Crawler

### DIFF
--- a/rasp/__init__.py
+++ b/rasp/__init__.py
@@ -1,6 +1,13 @@
 from rasp.engines.base import DefaultEngine
+from rasp.engines.selenium_engine import SeleniumEngine
+from rasp.engines.tor_engine import TorEngine
+from rasp.crawlers.base import DefaultBoundedCrawler
+from rasp.crawlers.asyncio_crawler import AsyncBoundedCrawler
 
 __all__ = [
     'SeleniumEngine',
-    'TorEngine'
+    'TorEngine',
+    'DefaultEngine',
+    'DefaultBoundedCrawler',
+    'AsyncBoundedCrawler'
 ]

--- a/rasp/__init__.py
+++ b/rasp/__init__.py
@@ -1,8 +1,6 @@
-from rasp.base import DefaultEngine
-from rasp.tor_engine import TorEngine
+from rasp.engines.base import DefaultEngine
 
 __all__ = [
-    'DefaultEngine',
     'SeleniumEngine',
     'TorEngine'
 ]

--- a/rasp/crawlers/__init__.py
+++ b/rasp/crawlers/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'willmcginnis'

--- a/rasp/crawlers/asyncio_crawler.py
+++ b/rasp/crawlers/asyncio_crawler.py
@@ -1,0 +1,77 @@
+import asyncio
+import copy
+import time
+from rasp import DefaultEngine
+
+__author__ = 'willmcginnis'
+
+
+class AsyncBoundedCrawler:
+    """
+    """
+
+    def __init__(self, engine, urls, callback, n_workers=5):
+        # The base enigne passed in will be used to create our consumers
+        self._engine = engine
+        self._callback = callback
+
+        # An asyncio queue is how we communicate with our consumers
+        self._queue = asyncio.Queue(maxsize=n_workers)
+        self._loop = asyncio.get_event_loop()
+
+        # enqueue our initial data, and start the consumers
+        self._producer = self._loop.create_task(self.enqueue_many(urls))
+        self._consumers = []
+        for idx in range(n_workers):
+            self._consumers.append(asyncio.ensure_future(self.consumer('worker_%s' % (idx, ))))
+
+        self._tasks = self._consumers # + [self._producer]
+
+    async def _main(self):
+        await asyncio.wait(self._tasks)
+
+    async def enqueue_many(self, urls):
+        for url in urls:
+            await self._queue.put(url)
+        await self._queue.join()
+
+    async def consumer(self, consumer_id):
+        engine = copy.deepcopy(self._engine)
+        while not self._queue.empty():
+            url = await self._queue.get()
+            if url is None:
+                self._queue.task_done()
+                break
+            else:
+                wp = engine.get_page_source(url)
+                self._callback(wp)
+                self._queue.task_done()
+
+    def run(self):
+        try:
+            self._loop.run_until_complete(self._main())
+        finally:
+            for task in asyncio.Task.all_tasks():
+                task.cancel()
+            self._loop.close()
+
+    def stop(self):
+        self._loop.close()
+
+def example_callback(wp):
+    print('...')
+
+if __name__ == '__main__':
+    # Hacky benchmark
+    # - workers=1, range=100, 100.97s
+    # - workers=3, range=100, 18.1s
+    # - workers=10, range=100, 9.3s
+
+    data = ('https://www.google.com?q=%s' % _ for _ in range(10))
+    engine = DefaultEngine()
+    start_time = time.time()
+    crawler = AsyncBoundedCrawler(engine, data, callback=example_callback, n_workers=10)
+    crawler.run()
+    end_time = time.time()
+    print('%s elapsed' % (end_time - start_time, ))
+

--- a/rasp/crawlers/base.py
+++ b/rasp/crawlers/base.py
@@ -1,80 +1,32 @@
-import asyncio
-import random
-import copy
-import time
 from rasp.engines.base import DefaultEngine
+import time
 
 __author__ = 'willmcginnis'
 
 
-class AsyncBoundedCrawler:
-    """
-    """
-
-    def __init__(self, engine, urls, n_workers=5):
-        # The base enigne passed in will be used to create our consumers
+class DefaultBoundedCrawler:
+    def __init__(self, engine, urls, callback):
         self._engine = engine
+        self._data = urls
+        self._callback = callback
 
-        # An asyncio queue is how we communicate with our consumers
-        self._queue = asyncio.Queue(maxsize=n_workers)
-        self._loop = asyncio.get_event_loop()
-
-        # enqueue our initial data, and start the consumers
-        self._producer = self._loop.create_task(self.enqueue_many(urls))
-        self._consumers = []
-        for idx in range(n_workers):
-            self._consumers.append(asyncio.ensure_future(self.consumer('worker_%s' % (idx, ))))
-
-        self._tasks = self._consumers # + [self._producer]
-
-    async def _main(self):
-        await asyncio.wait(self._tasks)
-
-    async def enqueue_many(self, urls):
-        for url in urls:
-            await self._queue.put(url)
-        await self._queue.join()
-        print('queue finished')
-
-    async def consumer(self, consumer_id):
-        print('starting up consumer: %s' % (consumer_id, ))
-        engine = copy.deepcopy(self._engine)
-        while not self._queue.empty():
-            url = await self._queue.get()
-            if url is None:
-                self._queue.task_done()
-                print('shutting down consumer: %s' % (consumer_id, ))
-                break
-            else:
-                wp = engine.get_page_source(url)
-                print('%s: %s' % (url, consumer_id, ))
-                # for testing
-                await asyncio.sleep(random.random())
-                self._queue.task_done()
-        print('shutting down consumer: %s' % (consumer_id, ))
+    def _process(self, url):
+        wp = self._engine.get_page_source(url)
+        self._callback(wp)
 
     def run(self):
-        try:
-            self._loop.run_until_complete(self._main())
-        finally:
-            for task in asyncio.Task.all_tasks():
-                task.cancel()
-            self._loop.close()
+        for url in self._data:
+            self._process(url)
 
-    def stop(self):
-        self._loop.close()
+
+def example_callback(wp):
+    print('...')
 
 if __name__ == '__main__':
-    # Hacky benchmark
-    # - workers=1, range=100, 100.97s
-    # - workers=3, range=100, 18.1s
-    # - workers=10, range=100, 9.3s
-
-    data = ('https://www.google.com?q=%s' % _ for _ in range(100))
+    data = ('https://www.google.com?q=%s' % _ for _ in range(10))
     engine = DefaultEngine()
-
     start_time = time.time()
-    crawler = AsyncBoundedCrawler(engine, data, 10)
+    crawler = DefaultBoundedCrawler(engine, data, callback=example_callback)
     crawler.run()
     end_time = time.time()
     print('%s elapsed' % (end_time - start_time, ))

--- a/rasp/crawlers/base.py
+++ b/rasp/crawlers/base.py
@@ -1,0 +1,80 @@
+import asyncio
+import random
+import copy
+import time
+from rasp.engines.base import DefaultEngine
+
+__author__ = 'willmcginnis'
+
+
+class AsyncBoundedCrawler:
+    """
+    """
+
+    def __init__(self, engine, urls, n_workers=5):
+        # The base enigne passed in will be used to create our consumers
+        self._engine = engine
+
+        # An asyncio queue is how we communicate with our consumers
+        self._queue = asyncio.Queue(maxsize=n_workers)
+        self._loop = asyncio.get_event_loop()
+
+        # enqueue our initial data, and start the consumers
+        self._producer = self._loop.create_task(self.enqueue_many(urls))
+        self._consumers = []
+        for idx in range(n_workers):
+            self._consumers.append(asyncio.ensure_future(self.consumer('worker_%s' % (idx, ))))
+
+        self._tasks = self._consumers # + [self._producer]
+
+    async def _main(self):
+        await asyncio.wait(self._tasks)
+
+    async def enqueue_many(self, urls):
+        for url in urls:
+            await self._queue.put(url)
+        await self._queue.join()
+        print('queue finished')
+
+    async def consumer(self, consumer_id):
+        print('starting up consumer: %s' % (consumer_id, ))
+        engine = copy.deepcopy(self._engine)
+        while not self._queue.empty():
+            url = await self._queue.get()
+            if url is None:
+                self._queue.task_done()
+                print('shutting down consumer: %s' % (consumer_id, ))
+                break
+            else:
+                wp = engine.get_page_source(url)
+                print('%s: %s' % (url, consumer_id, ))
+                # for testing
+                await asyncio.sleep(random.random())
+                self._queue.task_done()
+        print('shutting down consumer: %s' % (consumer_id, ))
+
+    def run(self):
+        try:
+            self._loop.run_until_complete(self._main())
+        finally:
+            for task in asyncio.Task.all_tasks():
+                task.cancel()
+            self._loop.close()
+
+    def stop(self):
+        self._loop.close()
+
+if __name__ == '__main__':
+    # Hacky benchmark
+    # - workers=1, range=100, 100.97s
+    # - workers=3, range=100, 18.1s
+    # - workers=10, range=100, 9.3s
+
+    data = ('https://www.google.com?q=%s' % _ for _ in range(100))
+    engine = DefaultEngine()
+
+    start_time = time.time()
+    crawler = AsyncBoundedCrawler(engine, data, 10)
+    crawler.run()
+    end_time = time.time()
+    print('%s elapsed' % (end_time - start_time, ))

--- a/rasp/engines/__init__.py
+++ b/rasp/engines/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'willmcginnis'

--- a/rasp/engines/base.py
+++ b/rasp/engines/base.py
@@ -1,10 +1,9 @@
-import datetime
-import time
 from copy import deepcopy
-
 import requests
-
+from rasp.webpage import Webpage
 from rasp.constants import DEFAULT_USER_AGENT
+
+__author__ = 'willmcginnis'
 
 
 class Engine(object):
@@ -71,51 +70,3 @@ class DefaultEngine(Engine):
         if response.status_code is not requests.codes.ok:
             return
         return Webpage(url, source=str(response.content))
-
-
-class Webpage(object):
-    def __init__(self, url=None, source=None):
-        """The Webpage object represents all we know about a single scraped page.
-
-        The Webpage object is the key object constructed by an engine to represent what we know about a given webpage.
-        It includes things like the page source, url, and date of access.
-
-        :param url: the url of the webpage you are representing
-        :param source: the source, as text of the webpage.
-        :return: Webpage
-        """
-
-        self._url = url
-        self._source = source
-        self._access_timestamp = time.time()
-
-    @property
-    def source(self):
-        """Source of the webpage, in text.
-        """
-        return self._source
-
-    @property
-    def url(self):
-        """Url of the webpage accessed
-        """
-        return self._url
-
-    @property
-    def access_timestamp(self):
-        """Date of access of the webpage data, as a unix timestamp in UTC
-        """
-        return self._access_timestamp
-
-    @property
-    def access_datetime(self):
-        """Date of access of the webpage data, as a datetime object
-        """
-        return datetime.datetime.utcfromtimestamp(self.access_timestamp)
-
-    @access_datetime.setter
-    def access_datetime(self, access_datetime):
-        self._access_timestamp = access_datetime.timestamp()
-
-    def __repr__(self):
-        return "url: {} at {}".format(self.url, self.access_datetime.strftime('%Y-%m-%d %H:%M:%S'))

--- a/rasp/engines/selenium_engine.py
+++ b/rasp/engines/selenium_engine.py
@@ -1,7 +1,8 @@
 import selenium
 import selenium.webdriver
 
-from rasp.base import Engine, Webpage
+from rasp.webpage import Webpage
+from rasp.engines.base import Engine
 from rasp.errors import EngineError
 
 

--- a/rasp/engines/tor_engine.py
+++ b/rasp/engines/tor_engine.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from stem import Signal
 from stem.connection import connect
 
-from rasp.base import DefaultEngine
+from rasp import DefaultEngine
 from rasp.errors import EngineError
 
 

--- a/rasp/webpage.py
+++ b/rasp/webpage.py
@@ -1,0 +1,50 @@
+import datetime
+import time
+
+
+class Webpage(object):
+    def __init__(self, url=None, source=None):
+        """The Webpage object represents all we know about a single scraped page.
+
+        The Webpage object is the key object constructed by an engine to represent what we know about a given webpage.
+        It includes things like the page source, url, and date of access.
+
+        :param url: the url of the webpage you are representing
+        :param source: the source, as text of the webpage.
+        :return: Webpage
+        """
+
+        self._url = url
+        self._source = source
+        self._access_timestamp = time.time()
+
+    @property
+    def source(self):
+        """Source of the webpage, in text.
+        """
+        return self._source
+
+    @property
+    def url(self):
+        """Url of the webpage accessed
+        """
+        return self._url
+
+    @property
+    def access_timestamp(self):
+        """Date of access of the webpage data, as a unix timestamp in UTC
+        """
+        return self._access_timestamp
+
+    @property
+    def access_datetime(self):
+        """Date of access of the webpage data, as a datetime object
+        """
+        return datetime.datetime.utcfromtimestamp(self.access_timestamp)
+
+    @access_datetime.setter
+    def access_datetime(self, access_datetime):
+        self._access_timestamp = access_datetime.timestamp()
+
+    def __repr__(self):
+        return "url: {} at {}".format(self.url, self.access_datetime.strftime('%Y-%m-%d %H:%M:%S'))

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,12 +1,13 @@
 import os
 from unittest.mock import patch
 
-import betamax
-import pytest
 import requests
 
-from rasp.base import DefaultEngine, Webpage
-from rasp.tor_engine import TorEngine
+import betamax
+import pytest
+from rasp.webpage import Webpage
+from rasp import DefaultEngine
+from rasp.engines.tor_engine import TorEngine
 
 with betamax.Betamax.configure() as config:
     current_dir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
In particular, note the class in crawlers/base.py.  It is a self contained asyncio-powered crawler, that scales on one machine pretty nicely, since so much of this task is IO bound.  For a bit of an idea of performance, pulling down a bunch of google search pages with the DefaultEngine with different numbers of workers takes:
```
workers=1, N-pages=100, 100.97s
workers=3, N-pages=100, 18.1s
workers=10, N-pages=100, 9.3s
```
It does currently make an assumption of a bounded input, so you pass in the urls collection and it will churn through that and then be done.  That collection can be a generator though, so we can probably be creative there for large lists of URLs.  

There is a use-case where when scraping one URL, you find another that you'd also like to scrape, that isn't really neatly supported here (maybe the consumers can directly put into the queue?).  Also what to actually do with the output object isn't really fleshed out (maybe pass a callback into the `__init__`?).

 Looking for some feedback.  My thinking was that a decent UX for the crawlers would be something like:

```
data = (foo for foo in bar) # some collection of urls
engine = DefaultEngine() # define some engine

# pass engine, data and kwargs to a crawler of some sort
crawler = AsyncBoundedCrawler(engine, data, **kwargs)

# blocking call to run() to process the urls.
crawler.run()
```

Is that more of less what ya'll had in mind?