### PR TITLE
Configurable Tor signaling behavior

### DIFF
--- a/rasp/base.py
+++ b/rasp/base.py
@@ -67,9 +67,12 @@ class DefaultEngine(Engine):
         try:
             return getattr(TmpEngine, method_name)
         except AttributeError:
-            raise NotImplementedError('Class {} does not implement {}'.format(class_name, func_name))
+            raise NotImplementedError('Class {} does not implement {}'.format(class_name, method_name))
 
-    def get_page_source(self, url, params=None, headers=None):
+    def get_page_source(self, url,
+                        params=None,
+                        headers=None,
+                        pre_fetch_callback=None):
         """Fetches the specified url.
 
         Attributes:
@@ -85,6 +88,8 @@ class DefaultEngine(Engine):
         """
         if not url:
             raise ValueError('url needs to be specified')
+        if pre_fetch_callback:
+            pre_fetch_callback()
 
         merged_headers = deepcopy(self.headers)
         if isinstance(headers, dict):

--- a/rasp/base.py
+++ b/rasp/base.py
@@ -25,10 +25,11 @@ class DefaultEngine(Engine):
         headers (dict): Base headers for all requests.
     """
 
-    def __init__(self, headers=None):
+    def __init__(self, headers=None, pre_fetch_callback=None):
         self.session = self._session()
         self.headers = headers or {'User-Agent': DEFAULT_USER_AGENT}
         self.session.headers.update(self.headers)
+        self.callback = pre_fetch_callback
 
     def __copy__(self):
         return DefaultEngine(self.headers)
@@ -71,8 +72,7 @@ class DefaultEngine(Engine):
 
     def get_page_source(self, url,
                         params=None,
-                        headers=None,
-                        pre_fetch_callback=None):
+                        headers=None):
         """Fetches the specified url.
 
         Attributes:
@@ -88,8 +88,8 @@ class DefaultEngine(Engine):
         """
         if not url:
             raise ValueError('url needs to be specified')
-        if pre_fetch_callback:
-            pre_fetch_callback()
+
+        if self.callback: self.callback()
 
         merged_headers = deepcopy(self.headers)
         if isinstance(headers, dict):

--- a/rasp/errors.py
+++ b/rasp/errors.py
@@ -4,3 +4,7 @@ class EngineError(Exception):
 
 class MasterError(Exception):
     pass
+
+
+class ControllerError(Exception):
+    pass

--- a/rasp/tor_engine.py
+++ b/rasp/tor_engine.py
@@ -1,12 +1,167 @@
 import getpass
 import os
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 
 from stem import Signal
 from stem.connection import connect
 
 from rasp.base import DefaultEngine
-from rasp.errors import EngineError
+from rasp.errors import ControllerError
+
+
+class TorController(object):
+    """
+    Attributes:
+        address (str): IP address of Tor SOCKS proxy to connect,
+            can also be set with the ``RASP_TOR_ADDRESS``
+            environment variable.
+        control_port (int, optional): Port number for control
+            port usage to refresh endpoint address,
+            can also be set with the ``RASP_TOR_CONTROL_PASSWORD``
+            environment variable.
+        control_password (str, optional): Password to protect control
+            port usage,
+            can also be set with the ``RASP_TOR_CONTROL_PORT``
+            environment variable.
+        callback (callable, optional): A function that returns a boolean value
+            to determine when to send a signal to Tor"""
+
+    def __init__(self,
+                 address=None,
+                 port=None,
+                 password=None,
+                 signal_limiter=None):
+        self.address = (
+            address
+            or os.environ.get('RASP_TOR_ADDRESS')
+            or '127.0.0.1'
+        )
+        self.control_port = (
+            port
+            or os.environ.get('RASP_TOR_CONTROL_PORT')
+            or 9051
+        )
+        self.control_password = (
+            password
+            or os.environ.get('RASP_TOR_CONTROL_PASSWORD')
+            or getpass.getpass("Tor control password: ")
+        )
+        self.limiter = signal_limiter
+
+    def __copy__(self):
+        return TorController(
+            address=self.address,
+            port=self.port,
+            password=self.control_password
+        )
+
+    def _enforce_connection(method):
+        """Method decorator to enforce that the connection was established"""
+
+        def enforce(self, *args, **kwargs):
+            if not hasattr(self, 'connection'):
+                raise ControllerError(
+                    'Signal controller has not been opened'
+                )
+            return method(self, *args, **kwargs)
+
+        return enforce
+
+    def open(self):
+        """Establishes a connection to the Tor server"""
+        info = (self.address, self.port)
+        self.connection = connect(
+            control_port=info,
+            password=self.password
+        )
+
+    @_enforce_connection
+    def close(self):
+        """Closes the TorController connection"""
+        self.connection.close()
+
+    @_enforce_connection
+    def ready_to_signal(self):
+        """Checks to see if the Tor server is available to be signalled.
+
+        The availability only applies to the instance's connection, and
+        doesn't take into account any other instances.
+
+        Returns:
+            True if signal can be sent, False if not
+        """
+        return self.connection.is_newnym_available()
+
+    @_enforce_connection
+    def signal(self):
+        """Refreshes the mapping of nodes we connect through.
+
+        When a new path from the user to the destination is required, this
+        method refreshes the node path we use to connect. This gives us a new IP
+        address with which the destination sees.
+        """
+        if self.ready_to_signal():
+            self.connection.signal(Signal.NEWNYM)
+
+    def limited_signal(self):
+        if self.ready_to_signal() and self.limiter():
+            self.signal()
+
+    @contextmanager
+    def connection(self):
+        """Context manager to automatically handle closing the connection"""
+        try:
+            self.open()
+            yield
+        finally:
+            self.close()
+
+    @staticmethod
+    def call_limited(request_amount):
+        """Returns a function that returns True when the
+            number of calls to it is equal to
+            ``request_amount``.
+
+            Parameters:
+                request_amount (int): the time to wait before
+                the returned function will return True
+        """
+
+        def call_limit():
+            call_limit.total_calls += 1
+            enough_calls = call_limit.total_calls == request_amount
+            if enough_calls:
+                call_limit.total_calls = 0
+                return True
+            else:
+                return False
+
+        call_limit.total_calls = 0
+        return call_limit
+
+    @staticmethod
+    def time_limited(time_window_seconds):
+        """Returns a function that returns True when the
+        elapsed time is greater than ``time_window_seconds``
+        from now.
+
+        Parameters:
+            time_window_seconds (float): the time to wait before
+            the returned function will return True
+        """
+
+        def time_limit():
+            delta = timedelta(seconds=time_window_seconds)
+            out_of_window = time_limit.last_signal <= (datetime.now() - delta)
+            if out_of_window:
+                time_limit.last_signal = datetime.now()
+                return True
+            else:
+                return False
+
+        time_limit.last_signal = datetime.now()
+        return time_limit
 
 
 class TorEngine(DefaultEngine):
@@ -26,22 +181,12 @@ class TorEngine(DefaultEngine):
         port (int): Port number of Tor SOCKS proxy for web requests,
             can also be set with the ``RASP_TOR_PORT``
             environment variable.
-        control_port (int, optional): Port number for control
-            port usage to refresh endpoint address,
-            can also be set with the ``RASP_TOR_CONTROL_PASSWORD``
-            environment variable.
-        control_password (str, optional): Password to protect control
-            port usage,
-            can also be set with the ``RASP_TOR_CONTROL_PORT``
-            environment variable.
      """
 
     def __init__(self,
                  headers=None,
                  address=None,
-                 port=None,
-                 control_port=None,
-                 control_password=None):
+                 port=None):
         super(TorEngine, self).__init__(headers)
 
         self.address = (
@@ -54,16 +199,6 @@ class TorEngine(DefaultEngine):
             or os.environ.get('RASP_TOR_PORT')
             or 9050
         )
-        self.control_password = (
-            control_password
-            or os.environ.get('RASP_TOR_CONTROL_PASSWORD')
-            or getpass.getpass("Tor control password: ")
-        )
-        self.control_port = (
-            control_port
-            or os.environ.get('RASP_TOR_CONTROL_PORT')
-            or 9051
-        )
 
         proxy_uri = 'socks5://{}:{}'.format(self.address, self.port)
         proxies = {'http': proxy_uri, 'https': proxy_uri}
@@ -74,58 +209,5 @@ class TorEngine(DefaultEngine):
             self.data,
             self.headers,
             self.address,
-            self.port,
-            self.control_port,
-            self.control_password,
+            self.port
         )
-
-    @contextmanager
-    def refreshable_ip(self):
-        try:
-            self.open_controller()
-            yield
-        finally:
-            self.close_controller()
-
-    def open_controller(self):
-        info = (self.address, self.control_port)
-        self.controller = connect(
-            control_port=info,
-            password=self.control_password
-        )
-
-    def close_controller(self):
-        self.controller.close()
-
-    def refresh_ip(self):
-        """Refreshes the mapping of nodes we connect through.
-
-        When a new path from the user to the destination is required, this
-        method refreshes the node path we use to connect. This gives us a new IP
-        address with which the destination sees."""
-        if not hasattr(self, 'controller'):
-            raise EngineError('Signal controller has not been activated'
-                              ', cannot refresh IP address')
-
-        self.controller.signal(Signal.NEWNYM)
-
-    def get_page_source(self, url, params=None,
-                        headers=None, refresh_ip=False):
-        """Fetches the specified url.
-
-        Attributes:
-            url (str): The url of which to fetch the page source code.
-            params (dict, optional): Key\:Value pairs to be converted to
-                x-www-form-urlencoded url parameters_.
-            headers (dict, optional): Extra headers to be merged into
-                base headers for current Engine before requesting url.
-            refresh_ip (bool, optional): Determines whether or not
-                we want to get a new IP with which to connect ``url``.
-        Returns:
-            ``rasp.base.Webpage`` if successful, ``None`` if not
-
-        .. _parameters: http://docs.python-requests.org/en/master/user/quickstart/#passing-parameters-in-urls
-        """
-        if refresh_ip:
-            self.refresh_ip()
-        return super(TorEngine, self).get_page_source(url, params=params, headers=headers)

--- a/rasp/tor_engine.py
+++ b/rasp/tor_engine.py
@@ -46,7 +46,11 @@ class TorController(object):
             or os.environ.get('RASP_TOR_CONTROL_PASSWORD')
             or getpass.getpass("Tor control password: ")
         )
-        self.limiter = signal_limiter
+
+        def default_limiter(): return True
+        self.limiter = (
+            signal_limiter or default_limiter
+        )
 
     def __copy__(self):
         return TorController(


### PR DESCRIPTION
Ticket: #14 
Type: Enhancement

## Changes

- Add `TorController` class

## Documentation

We need to be able to configure when the controller sends the signal with as little configuration after instantiation.  First step was to remove the functionality from the `TorEngine` class.  In addition, we needed an easy way to have the controller be both configurable, and also keep track of each call to it.

## Impacted Areas

- `TorEngine`

## Checklist

- [ ] ~~Add information to the release notes documentation~~
- [ ] Add new feature to the usage documentation
- [x] Add tests